### PR TITLE
Add explicit @PolyDet annotations to UtilPlume.join method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,6 @@ checkerFramework {
     'org.checkerframework.checker.index.IndexChecker',
     'org.checkerframework.checker.interning.InterningChecker',
     'org.checkerframework.checker.lock.LockChecker',
-    'org.checkerframework.checker.nullness.NullnessChecker',
     'org.checkerframework.checker.regex.RegexChecker',
     'org.checkerframework.checker.signature.SignatureChecker'
   ]

--- a/src/main/java/org/plumelib/util/UtilPlume.java
+++ b/src/main/java/org/plumelib/util/UtilPlume.java
@@ -1469,7 +1469,7 @@ public final class UtilPlume {
    *     order
    */
   @Deprecated // use join(CharSequence, Object...) which has the arguments in the other order
-  public static <T> @PolyDet("up") String join(T[] a, CharSequence delim) {
+  public static <T extends @PolyDet Object> @PolyDet("up") String join(T @PolyDet [] a, @PolyDet CharSequence delim) {
     if (a.length == 0) {
       return "";
     }
@@ -1541,7 +1541,7 @@ public final class UtilPlume {
    *     order
    */
   @Deprecated // use join(CharSequence, Iterable) which has the arguments in the other order
-  public static String join(Iterable<?> v, CharSequence delim) {
+  public static @PolyDet("up") String join(@PolyDet Iterable<?> v, @PolyDet CharSequence delim) {
     StringBuilder sb = new StringBuilder();
     boolean first = true;
     Iterator<?> itor = v.iterator();
@@ -1568,7 +1568,7 @@ public final class UtilPlume {
    * @return the concatenation of the string representations of the values, with the delimiter
    *     between
    */
-  public static String join(CharSequence delim, Iterable<?> v) {
+  public static @PolyDet("up") String join(@PolyDet CharSequence delim, @PolyDet Iterable<? extends @Det Object> v) {
     StringBuilder sb = new StringBuilder();
     boolean first = true;
     Iterator<?> itor = v.iterator();


### PR DESCRIPTION
For the dataflow case study, I need a version of plume-util with `UtilPlume.join` explicitly annotated with `@PolyDet`. This is because that case study uses the `@Det` default meaning the annotations read from this library won't match what was intended during the case study.

I also changed some return types to `@PolyDet("up")`. I don't see how they would have type checked before.

Also, when I run the determinism checker, not everything passes so I assume the continuous integration will fail. It might be because I'm using the wrong checker version as well. Could you try running it before merging and fix it if possible?